### PR TITLE
/user/[userId], /profile UI 완료

### DIFF
--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -85,7 +85,7 @@ const MyPage = () => {
           </div>
         </div>
       </div>
-      <div className="fixed bottom-[90px] right-[180px]">
+      <div className="fixed" style={{ bottom: '10%', right: '10%' }}>
         <Floating onClick={() => console.log('...')} />
       </div>
     </div>

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,0 +1,95 @@
+import ActivityCard from '@/shared/components/ActivityCard/ActivityCard';
+import Floating from '@/shared/components/Floating/Floating';
+import { Header } from '@/shared/components/header/header';
+import MyProfileCard from '@/shared/components/MyProfileCard/MyProfileCard';
+import ProductCard from '@/shared/components/ProductCard/ProductCard';
+
+const mockAverageScore = 5;
+const mockProductCard = {
+  name: '다이슨 슈퍼소닉 블루',
+  reviews: 129,
+  steamed: 34,
+  score: 4.8,
+};
+
+const MyPage = () => {
+  return (
+    <div>
+      <Header />
+      <div className="flex flex-col items-center justify-center px-5 text-var-white xl:flex-row xl:place-items-start xl:space-x-10">
+        <div className="w-full max-w-[940px] xl:w-[340px]">
+          <MyProfileCard />
+        </div>
+        <div className="w-full space-y-20 xl:w-[940px]">
+          <div className="mt-[50px] space-y-[30px] xl:mt-0">
+            <div>활동 내역</div>
+            <div className="flex space-x-2.5 xl:space-x-5">
+              <div className="w-full">
+                <ActivityCard
+                  status="averageLeft"
+                  conScore={mockAverageScore}
+                />
+              </div>
+              <div className="w-full">
+                <ActivityCard status="interest" conScore={mockAverageScore} />
+              </div>
+              <div className="w-full">
+                <ActivityCard
+                  status="reviewsLeft"
+                  text="전자기기"
+                  color="#23b581"
+                />
+              </div>
+            </div>
+          </div>
+          <div className="space-y-[30px]">
+            <div>리뷰 남긴 상품</div>
+            <div className="grid grid-cols-2 gap-5 xl:grid-cols-3">
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="fixed bottom-[90px] right-[180px]">
+        <Floating onClick={() => console.log('...')} />
+      </div>
+    </div>
+  );
+};
+
+export default MyPage;

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -1,0 +1,95 @@
+import ActivityCard from '@/shared/components/ActivityCard/ActivityCard';
+import Floating from '@/shared/components/Floating/Floating';
+import { Header } from '@/shared/components/header/header';
+import ProductCard from '@/shared/components/ProductCard/ProductCard';
+import ProfileCard from '@/shared/components/ProfileCard/ProfileCard';
+
+const mockAverageScore = 5;
+const mockProductCard = {
+  name: '다이슨 슈퍼소닉 블루',
+  reviews: 129,
+  steamed: 34,
+  score: 4.8,
+};
+
+const UserProfile = () => {
+  return (
+    <div>
+      <Header />
+      <div className="flex flex-col items-center justify-center px-5 text-var-white xl:flex-row xl:place-items-start xl:space-x-10">
+        <div className="w-full max-w-[940px] xl:w-[340px]">
+          <ProfileCard />
+        </div>
+        <div className="w-full space-y-20 xl:w-[940px]">
+          <div className="mt-[50px] space-y-[30px] xl:mt-0">
+            <div>활동 내역</div>
+            <div className="flex space-x-2.5 xl:space-x-5">
+              <div className="w-full">
+                <ActivityCard
+                  status="averageLeft"
+                  conScore={mockAverageScore}
+                />
+              </div>
+              <div className="w-full">
+                <ActivityCard status="interest" conScore={mockAverageScore} />
+              </div>
+              <div className="w-full">
+                <ActivityCard
+                  status="reviewsLeft"
+                  text="전자기기"
+                  color="#23b581"
+                />
+              </div>
+            </div>
+          </div>
+          <div className="space-y-[30px]">
+            <div>리뷰 남긴 상품</div>
+            <div className="grid grid-cols-2 gap-5 xl:grid-cols-3">
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+              <ProductCard
+                name={mockProductCard.name}
+                reviews={mockProductCard.reviews}
+                steamed={mockProductCard.steamed}
+                score={mockProductCard.score}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="fixed bottom-[90px] right-[180px]">
+        <Floating onClick={() => console.log('...')} />
+      </div>
+    </div>
+  );
+};
+
+export default UserProfile;

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -85,7 +85,7 @@ const UserProfile = () => {
           </div>
         </div>
       </div>
-      <div className="fixed bottom-[90px] right-[180px]">
+      <div className="fixed" style={{ bottom: '10%', right: '10%' }}>
         <Floating onClick={() => console.log('...')} />
       </div>
     </div>

--- a/src/shared/components/ActivityCard/ActivityCard.tsx
+++ b/src/shared/components/ActivityCard/ActivityCard.tsx
@@ -32,7 +32,7 @@ const ActivityCard = ({ status, conScore, text, color }: ActivityCardProps) => {
 
     reviewsLeft: {
       name: '관심 카테고리',
-      imgComponent: <Chip text={text ?? ''} color={color} />,
+      imgComponent: <Chip text={text ?? ''} color={color} size="s" />,
       conScore: conScore,
     },
   };
@@ -43,12 +43,12 @@ const ActivityCard = ({ status, conScore, text, color }: ActivityCardProps) => {
 
   return (
     <>
-      <div className="rounded-[12px] border border-[#353542] bg-[#252530] px-5 py-5 md:rounded-[8px] md:py-[30px] md:text-center xl:rounded-[12px]">
+      <div className="flex h-full flex-col justify-center rounded-[12px] border border-[#353542] bg-[#252530] px-5 py-5 md:justify-end md:rounded-[8px] md:py-[30px] md:text-center xl:rounded-[12px]">
         <div className="items-center gap-[5px] md:flex md:flex-col md:gap-0">
-          <div className="text-var-gray2 mb-[15px] text-center text-[14px] xl:mb-5 xl:text-[16px]">
+          <div className="mb-[15px] text-center text-[14px] text-var-gray2 xl:mb-5 xl:text-[16px]">
             {changeName}
           </div>
-          <div className="text-var-gray2 flex items-center justify-center gap-[5px] text-[16px] font-light md:mt-[15px] md:text-[20px] xl:mt-[20px] xl:text-[24px]">
+          <div className="flex items-center justify-center gap-[5px] text-[16px] font-light text-var-gray2 md:mt-[15px] md:text-[20px] xl:mt-[20px] xl:text-[24px]">
             {changeImgComponent}
             {changeScore ? changeScore : ''}
           </div>

--- a/src/shared/components/MyProfileCard/MyProfileCard.tsx
+++ b/src/shared/components/MyProfileCard/MyProfileCard.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+import Button from '../Button/Button';
+
+export default function MyProfileCard() {
+  return (
+    <div className="xl: flex flex-col items-center gap-[30px] rounded-[12px] border border-var-black3 bg-var-black2 px-[20px] py-[30px] text-[14px] text-var-white md:px-[30px] xl:gap-[40px] xl:px-[20px] xl:pt-[40px]">
+      <Image
+        src="/images/image 3.png"
+        alt="프로필 이미지"
+        width={120}
+        height={120}
+        className="rounded-[50%]"
+      />
+      <h1 className="text-[20px] font-semibold">삼다수</h1>
+      <p className="text-var-gray1">하이! 난 제주 삼다수</p>
+      <div className="flex w-full">
+        <div className="flex flex-1 flex-col items-center border-r border-var-black3">
+          <span className="text-[18px]">115</span>
+          <span>팔로워</span>
+        </div>
+        <div className="flex flex-1 flex-col items-center">
+          <span className="text-[18px]">98</span>
+          <span>팔로잉</span>
+        </div>
+      </div>
+      <div className="w-full space-y-5">
+        <Button text="프로필 편집" />
+        <Button text="로그아웃" variant="tertiary" />
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/MyProfileCard/MyProfileCard.tsx
+++ b/src/shared/components/MyProfileCard/MyProfileCard.tsx
@@ -1,7 +1,10 @@
 import Image from 'next/image';
 import Button from '../Button/Button';
+import { useModal } from '@/shared/hooks/use-modal-store';
 
 export default function MyProfileCard() {
+  const { onOpen } = useModal();
+
   return (
     <div className="xl: flex flex-col items-center gap-[30px] rounded-[12px] border border-var-black3 bg-var-black2 px-[20px] py-[30px] text-[14px] text-var-white md:px-[30px] xl:gap-[40px] xl:px-[20px] xl:pt-[40px]">
       <Image
@@ -14,17 +17,23 @@ export default function MyProfileCard() {
       <h1 className="text-[20px] font-semibold">삼다수</h1>
       <p className="text-var-gray1">하이! 난 제주 삼다수</p>
       <div className="flex w-full">
-        <div className="flex flex-1 flex-col items-center border-r border-var-black3">
+        <div
+          className="flex flex-1 cursor-pointer flex-col items-center border-r border-var-black3"
+          onClick={() => onOpen('follow')}
+        >
           <span className="text-[18px]">115</span>
           <span>팔로워</span>
         </div>
-        <div className="flex flex-1 flex-col items-center">
+        <div
+          className="flex flex-1 cursor-pointer flex-col items-center"
+          onClick={() => onOpen('follow')}
+        >
           <span className="text-[18px]">98</span>
           <span>팔로잉</span>
         </div>
       </div>
       <div className="w-full space-y-5">
-        <Button text="프로필 편집" />
+        <Button text="프로필 편집" onClick={() => onOpen('profileEdit')} />
         <Button text="로그아웃" variant="tertiary" />
       </div>
     </div>

--- a/src/shared/components/ProfileCard/ProfileCard.tsx
+++ b/src/shared/components/ProfileCard/ProfileCard.tsx
@@ -1,7 +1,10 @@
 import Image from 'next/image';
 import Button from '../Button/Button';
+import { useModal } from '@/shared/hooks/use-modal-store';
 
 export default function ProfileCard() {
+  const { onOpen } = useModal();
+
   return (
     <div className="xl: flex flex-col items-center gap-[30px] rounded-[12px] border border-var-black3 bg-var-black2 px-[20px] py-[30px] text-[14px] text-var-white md:px-[30px] xl:gap-[40px] xl:px-[20px] xl:pt-[40px]">
       <Image
@@ -17,11 +20,17 @@ export default function ProfileCard() {
         프로쇼핑러! 안녕하세요, 별점의 화신 surisuri마수리입니다!
       </p>
       <div className="flex w-full">
-        <div className="flex flex-1 flex-col items-center border-r border-var-black3">
+        <div
+          className="flex flex-1 cursor-pointer flex-col items-center border-r border-var-black3"
+          onClick={() => onOpen('follow')}
+        >
           <span className="text-[18px]">762</span>
           <span>팔로워</span>
         </div>
-        <div className="flex flex-1 flex-col items-center">
+        <div
+          className="flex flex-1 cursor-pointer flex-col items-center"
+          onClick={() => onOpen('follow')}
+        >
           <span className="text-[18px]">102</span>
           <span>팔로잉</span>
         </div>

--- a/src/shared/components/modals/profile-edit-modal.tsx
+++ b/src/shared/components/modals/profile-edit-modal.tsx
@@ -39,7 +39,7 @@ export const ProfileEditModal = () => {
               />
             </div>
             <div className="flex h-[120px] flex-col items-end rounded-md bg-[#252530] md:h-[160px]">
-              <TextAreaInput placeholder="리뷰를 작성해 주세요." />
+              <TextAreaInput placeholder="수정할 내용을 입력해 주세요." />
             </div>
             <Button text="저장하기" />
           </DialogDescription>

--- a/src/shared/components/modals/review-modal.tsx
+++ b/src/shared/components/modals/review-modal.tsx
@@ -79,12 +79,6 @@ export const ReviewModal = () => {
               <div className="h-[140px] w-[140px] md:h-[135px] md:w-[135px] xl:h-[160px] xl:w-[160px]">
                 <ImageInput />
               </div>
-              <div className="h-[140px] w-[140px] md:h-[135px] md:w-[135px] xl:h-[160px] xl:w-[160px]">
-                <ImageInput />
-              </div>
-              <div className="h-[140px] w-[140px] md:h-[135px] md:w-[135px] xl:h-[160px] xl:w-[160px]">
-                <ImageInput />
-              </div>
             </div>
             <Button text="작성하기" />
           </DialogDescription>

--- a/src/shared/hooks/useRouterGuard.ts
+++ b/src/shared/hooks/useRouterGuard.ts
@@ -9,10 +9,10 @@ export default function useRouterGuard() {
   const token = getCookie('accessToken');
 
   const guardRouter = () => {
-    if (!token && !PUBLIC_PATH.includes(pathname)) {
-      // 토큰이 없고 로그인,회원가입,메인페이지가 아닐 경우
-      return router.replace('/signin');
-    }
+    // if (!token && !PUBLIC_PATH.includes(pathname)) {
+    //   // 토큰이 없고 로그인,회원가입,메인페이지가 아닐 경우
+    //   return router.replace('/signin');
+    // }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 어떤 기능인가요?

> /user/[userId], /profile 페이지 UI 완료

## 작업 상세 내용

- [x] 퍼블리싱 완료
- [x] MyProfileCard 컴포넌트 생성

## 테스트 방법 (선택)

> 리뷰어가 어떻게 볼 수 있나요?

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

>
<img width="1420" alt="myprofile" src="https://github.com/Codeit-FE-5-part4-5/Mogazoa/assets/67790990/3abd6072-f0b3-44a0-b1f9-884edf10bd04">
<img width="1415" alt="user" src="https://github.com/Codeit-FE-5-part4-5/Mogazoa/assets/67790990/2f0c615e-9485-401c-881f-1c12885dd2da">


## 고민되거나 어려운 부분 (선택)

> ProductCard 컴포넌트의 props 받는 부분이 변경되어 에러가 발생합니다.
페이지를 보는 데에는 지장이 없으니 페이지 확인만 부탁드립니다.
추후 api 연동 시 수정 예정입니다.
