### PR TITLE
feat: 리뷰어 랭킹 추가

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,7 @@ import ProductList from '@/shared/components/ProductList/ProductList';
 import useSearchRouter from '@/shared/hooks/useSearchRouter';
 import Spinner from '@/shared/components/Spinner/Spinner';
 import { validateArray } from '@/shared/utils/validateArray';
+import useGetFollowersRanking from '@/shared/models/user/follow/followers/useGetFollowersRanking';
 
 export default function Home() {
   const { currentQuery, handleRouterPush } = useChangeRouter();
@@ -26,6 +27,10 @@ export default function Home() {
     order: currentSortOrder,
     keyword: searchQuery,
   });
+
+  // 랭킹
+  const { data: rankingData } = useGetFollowersRanking();
+  const sliceRankingData = rankingData?.slice(0, 5);
 
   return (
     <MogazoaLayout>
@@ -45,7 +50,7 @@ export default function Home() {
           />
         </div>
         <div className="flex w-full max-w-[1250px] flex-col gap-[60px] md:min-w-0 xl:flex-row xl:gap-0">
-          <RankingList />
+          <RankingList rankingData={sliceRankingData} />
           <div className="flex-1">
             {currentQuery.category ? (
               <ProductList

--- a/src/shared/components/RankingCard/RankingCard.tsx
+++ b/src/shared/components/RankingCard/RankingCard.tsx
@@ -1,28 +1,43 @@
 import React from 'react';
 import Ranking from '../Chip/Ranking';
 import Image from 'next/image';
+import { FollowerRanking } from '@/shared/types/follow/followers/followers-type';
 
-// 기존 ranking을 어떻게 불러올지 모르므로 일단 any로 타입을 지정함.
-// 사용할 때 수정필요
+type RankingCardType = Omit<
+  FollowerRanking,
+  'updatedAt' | 'createdAt' | 'teamId' | 'id'
+> & {
+  ranking: number;
+};
 
-const RankingCard = ({ mockRanking }: any) => {
-  const { img, alt, name, follower, review } = mockRanking;
-
+const RankingCard = ({
+  image,
+  nickname,
+  description,
+  reviewCount,
+  followersCount,
+  ranking,
+}: RankingCardType) => {
   return (
     <div className="flex flex-shrink-0 items-center gap-2.5">
-      <div className="relative flex size-[42px] rounded-full bg-blue-50">
-        <Image src={img} alt={alt} fill />
+      <div className="relative flex size-[42px] overflow-hidden rounded-full border border-var-gray1">
+        <Image
+          src={image || 'images/user-no-image.svg'}
+          alt={description || '이미지 없음'}
+          layout="fill"
+          objectFit="cover"
+        />
       </div>
       <div className="flex flex-col gap-2">
         <div className="flex gap-2">
-          <Ranking ranking={0} />
+          <Ranking ranking={ranking} />
           <div className="text-[14px] font-normal text-var-white md:text-[16px]">
-            {name}
+            {nickname}
           </div>
         </div>
         <ul className="flex gap-3.5 text-[10px] font-light text-var-gray1 md:text-[12px]">
-          <li>팔로워 {follower}</li>
-          <li>리뷰 {review}</li>
+          <li>팔로워 {followersCount}</li>
+          <li>리뷰 {reviewCount}</li>
         </ul>
       </div>
     </div>

--- a/src/shared/components/RankingCard/RankingCard.tsx
+++ b/src/shared/components/RankingCard/RankingCard.tsx
@@ -22,10 +22,14 @@ const RankingCard = ({
     <div className="flex flex-shrink-0 items-center gap-2.5">
       <div className="relative flex size-[42px] overflow-hidden rounded-full border border-var-gray1">
         <Image
+          sizes="40px"
           src={image || 'images/user-no-image.svg'}
           alt={description || '이미지 없음'}
-          layout="fill"
-          objectFit="cover"
+          fill={true}
+          style={{
+            objectFit: 'contain',
+          }}
+          loading="eager"
         />
       </div>
       <div className="flex flex-col gap-2">

--- a/src/shared/components/RankingList/RankingList.tsx
+++ b/src/shared/components/RankingList/RankingList.tsx
@@ -1,23 +1,38 @@
+import { FollowerRanking } from '@/shared/types/follow/followers/followers-type';
 import RankingCard from '../RankingCard/RankingCard';
 
-export const RankingList: React.FC = () => {
-  const mockRanking = {
-    img: '/images/Ellipse48.svg',
-    alt: '예시2',
-    name: '리뷰왕',
-    follower: 1245,
-    review: 1243,
-  };
+interface Prop {
+  rankingData?: FollowerRanking[];
+}
 
+export const RankingList: React.FC<Prop> = ({ rankingData }) => {
   return (
-    <div className="no-scrollbar ml-[20px] mt-[45px] flex flex-col gap-[20px] overflow-x-auto bg-[#1C1C22] text-[#F1F1F5] xl:order-1 xl:h-full xl:w-[250px]">
+    <div className="ml-[20px] mt-[45px] flex flex-col gap-[20px] overflow-x-auto bg-[#1C1C22] text-[#F1F1F5] no-scrollbar xl:order-1 xl:h-full xl:w-[250px]">
       <div className="text-[14px]">리뷰어 랭킹</div>
       <div className="flex gap-[10px] xl:flex xl:flex-col xl:items-start xl:gap-[30px]">
-        <RankingCard mockRanking={mockRanking} />
-        <RankingCard mockRanking={mockRanking} />
-        <RankingCard mockRanking={mockRanking} />
-        <RankingCard mockRanking={mockRanking} />
-        <RankingCard mockRanking={mockRanking} />
+        {rankingData?.map((item, index) => {
+          const {
+            image,
+            nickname,
+            followersCount,
+            reviewCount,
+            description,
+            id,
+          } = item;
+          return (
+            followersCount > 0 && (
+              <RankingCard
+                key={id}
+                image={image}
+                nickname={nickname}
+                followersCount={followersCount}
+                reviewCount={reviewCount}
+                description={description}
+                ranking={index}
+              />
+            )
+          );
+        })}
       </div>
     </div>
   );

--- a/src/shared/models/user/follow/followers/useGetFollowersRanking.ts
+++ b/src/shared/models/user/follow/followers/useGetFollowersRanking.ts
@@ -1,0 +1,16 @@
+import { FollowerRanking } from '@/shared/types/follow/followers/followers-type';
+import axios from '@/shared/utils/axios';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetFollowersRanking = () => {
+  return useQuery<FollowerRanking[]>({
+    queryKey: ['users/ranking'],
+    queryFn: async () => {
+      const { data } = await axios.get('users/ranking');
+
+      return data;
+    },
+  });
+};
+
+export default useGetFollowersRanking;

--- a/src/shared/types/follow/followers/followers-type.ts
+++ b/src/shared/types/follow/followers/followers-type.ts
@@ -17,3 +17,8 @@ export interface Followers {
   nextCursor: number;
   list: FollowerItem[];
 }
+
+export interface FollowerRanking extends Follower {
+  followersCount: number;
+  reviewCount: number;
+}


### PR DESCRIPTION
## 어떤 기능인가요?

> 리뷰어 랭킹을 추가 했어요.

## 작업 상세 내용

- [x] 리뷰어 랭킹 관련 useQuery를 추가 했어요.
- [x] 리뷰어 랭킹 타입 추가 했어요.
- [x] 리뷰어 랭킹이 팔로워 수가 1명 이상일때만 순위에 나오게 추가했어요. (기존에 0명인 유저가 너무 많아 abcd순으로 닉네임을 그냥 가져오는듯 해서 굳이 띄울필요 없다고 판단했습니다.)
- [x] 랭킹은 5명까지만 나오게 추가했어요.
- [x] ranking 컴포넌트에 필요한 ranking prop은 map의 index로 넣었어요.
 
## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)
![스크린샷 2024-07-17 오후 3 43 31](https://github.com/user-attachments/assets/39cd90a4-14e5-4801-89c5-ec84c049d5bb)
![스크린샷 2024-07-17 오후 3 43 48](https://github.com/user-attachments/assets/3247d118-dad6-4b37-b3c2-44b888a243d1)
