### PR TITLE
feat: 명세서 관련 추가

### DIFF
--- a/src/shared/components/RankingCard/RankingCard.tsx
+++ b/src/shared/components/RankingCard/RankingCard.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import Ranking from '../Chip/Ranking';
 import Image from 'next/image';
 import { FollowerRanking } from '@/shared/types/follow/followers/followers-type';
+import { convertToK } from '@/shared/models/user/follow/followers/convertToK';
+import Link from 'next/link';
 
 type RankingCardType = Omit<
   FollowerRanking,
-  'updatedAt' | 'createdAt' | 'teamId' | 'id'
+  'updatedAt' | 'createdAt' | 'teamId'
 > & {
   ranking: number;
 };
@@ -17,6 +19,7 @@ const RankingCard = ({
   reviewCount,
   followersCount,
   ranking,
+  id,
 }: RankingCardType) => {
   return (
     <div className="flex flex-shrink-0 items-center gap-2.5">
@@ -32,17 +35,19 @@ const RankingCard = ({
           loading="eager"
         />
       </div>
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-2">
-          <Ranking ranking={ranking} />
-          <div className="text-[14px] font-normal text-var-white md:text-[16px]">
-            {nickname}
+      <div>
+        <Link href={`/user/${id}`} className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <Ranking ranking={ranking} />
+            <div className="text-[14px] font-normal text-var-white md:text-[16px]">
+              {nickname}
+            </div>
           </div>
-        </div>
-        <ul className="flex gap-3.5 text-[10px] font-light text-var-gray1 md:text-[12px]">
-          <li>팔로워 {followersCount}</li>
-          <li>리뷰 {reviewCount}</li>
-        </ul>
+          <ul className="flex gap-3.5 text-[10px] font-light text-var-gray1 md:text-[12px]">
+            <li>팔로워 {convertToK(followersCount)}</li>
+            <li>리뷰 {convertToK(reviewCount)}</li>
+          </ul>
+        </Link>
       </div>
     </div>
   );

--- a/src/shared/components/RankingList/RankingList.tsx
+++ b/src/shared/components/RankingList/RankingList.tsx
@@ -22,6 +22,7 @@ export const RankingList: React.FC<Prop> = ({ rankingData }) => {
           return (
             followersCount > 0 && (
               <RankingCard
+                id={id}
                 key={id}
                 image={image}
                 nickname={nickname}

--- a/src/shared/models/user/follow/followers/convertToK.ts
+++ b/src/shared/models/user/follow/followers/convertToK.ts
@@ -1,0 +1,6 @@
+export const convertToK = (num: number) => {
+  if (num >= 1000) {
+    return Math.floor(num / 1000) + 'k+';
+  }
+  return num.toString();
+};


### PR DESCRIPTION

## 작업 상세 내용

- [x] 팔로워 수와 리뷰수는 1,000을 넘어가면 1K+ (2천은 2k+, 3천은 3k+ ...) 로 표기합니다.
- [x] 리뷰어를 클릭할 경우 해당 유저의 프로필 화면/user/{userId} 으로 이동합니다.